### PR TITLE
추가: 프리즈마 도커 연결 및 구축

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+version: '2'
+services:
+  prisma:
+    image: prismagraphql/prisma:1.34
+    restart: always
+    ports:
+    - "4466:4466"
+    environment:
+      PRISMA_CONFIG: |
+        port: 4466
+        # uncomment the next line and provide the env var PRISMA_MANAGEMENT_API_SECRET=my-secret to activate cluster security
+        # managementApiSecret: my-secret
+        databases:
+          default:
+            connector: mysql
+            host: YOUR_HOSTNAME
+            user: YOUR_USERNAME
+            password: YOUR_PASSWORD
+            rawAccess: true
+            port: 3306
+            migrations: true
+  mysql:
+    image: mysql:5.7
+    restart: always
+    # Uncomment the next two lines to connect to your your database from outside the Docker environment, e.g. using a database GUI like Workbench
+    # ports:
+    # - "3306:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: MYSQL_PASSWORD
+    volumes:
+      - mysql:/var/lib/mysql
+volumes:
+  mysql:


### PR DESCRIPTION
Docker 기반 mysql prisma 구축 및 배포
docker-composed.yml 내부의 host, user, password, root_mysql_password 입력 필요