### PR TITLE
[임문수]w2_리뷰요청_블록연결을 위한 커넥션 구현

### DIFF
--- a/block_manager.js
+++ b/block_manager.js
@@ -1,0 +1,7 @@
+import Connection_db from './connection_db';
+import Dragging from './dragging';
+
+const connectionDB = new Connection_db();
+const dragging = new Dragging();
+
+export { connectionDB, dragging };

--- a/connection.js
+++ b/connection.js
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2011 Google LLC
+ * 참고: https://github.com/google/blockly
+ * goolge blockly을 참고하여 개발.
+ *
+ * boostcamp the duck
+ *
+ *
+ **/
+
+import { dragging } from "./block_manager";
+
+const Connection = function(type, source, diff_x, diff_y) {
+  this.type = type;
+  this.source = source;
+  this.diff_x = 0;
+  this.diff_y = 0;
+  this.isSelected = false;
+};
+
+Connection.prototype.getType = function() {
+  return this.type;
+};
+
+Connection.prototype.revertType = function(type) {
+  return (type + 2) % 4;
+};
+
+Connection.prototype.X_ = function() {
+  if (this.source.isDragging) {
+    return dragging.getCurrentBlockX() + this.diff_x;
+  }
+  return this.source.X + this.diff_x;
+};
+
+Connection.prototype.Y_ = function() {
+  if (this.source.isDragging) {
+    return dragging.getCurrentBlockY() + this.diff_y;
+  }
+  return this.source.Y + this.diff_y;
+};
+
+Connection.prototype.canConnect = function(connect, radius) {
+  return (
+    Math.abs(connect.X_() - this.X_()) <= radius &&
+    connect.source !== this.source &&
+    connect.type === this.revertType(this.type)
+  );
+};
+
+Connection.prototype.distanceFrom = function(connect) {
+  return Math.sqrt(
+    Math.pow(this.X_() - connect.X_(), 2) +
+      Math.pow(this.X_() - connect.X_(), 2)
+  );
+};
+
+export default Connection;

--- a/connection_db.js
+++ b/connection_db.js
@@ -1,0 +1,82 @@
+/**
+ * @license
+ * Copyright 2011 Google LLC
+ * 참고: https://github.com/google/blockly
+ * goolge blockly을 참고하여 개발.
+ *
+ * boostcamp the duck
+ *
+ * */
+
+const ConnectionDB = function() {
+  this.connections = [];
+};
+
+ConnectionDB.prototype.addConnection = function(connection) {
+  this.connections.push(connection);
+};
+
+ConnectionDB.prototype.isInYRange = function(connectIdx, y, maxRadius) {
+  return Math.abs(this.connections[connectIdx].test_y - y) <= maxRadius;
+};
+
+ConnectionDB.prototype.findClosetConnection = function(connect, maxRadius) {
+  const startIdx = this.findStartIdxForConnection(connect.X_(), connect.Y_());
+  let closetConnection = null;
+  let bestRadius = maxRadius;
+  let temp;
+  let findBackword = startIdx - 1;
+  if (startIdx >= this.connections.length) {
+    return -1;
+  }
+  while (
+    findBackword >= 0 &&
+    this.isInYRange(findBackword, connect.Y_(e), bestRadius)
+  ) {
+    temp = this.connections[findBackword];
+    if (connect.canConnect(temp, bestRadius)) {
+      closetConnection = temp;
+      bestRadius = temp.distanceFrom(connect);
+    }
+    findBackword--;
+  }
+  let findForward = startIdx;
+  while (
+    findForward < this.connections.length &&
+    this.isInYRange(findForward, connect.Y_(e), bestRadius)
+  ) {
+    temp = this.connections[findForward];
+    if (connect.canConnect(temp, bestRadius)) {
+      closetConnection = temp;
+      bestRadius = temp.distanceFrom(connect);
+    }
+    findForward++;
+  }
+  return { connection: closetConnection, radius: bestRadius };
+};
+
+ConnectionDB.prototype.findStartIdxForConnection = function(test_x, test_y) {
+  if (!this.connections.length) {
+    return 0;
+  }
+  let positionMin = 0;
+  let positionMax = this.connections.length;
+  while (positionMin < positionMax) {
+    const postionMid = Math.floor((positionMin + positionMax) / 2);
+    if (this.connections[postionMid].test_y < test_y) {
+      positionMin = postionMid + 1;
+    } else if (this.connections[postionMid].test_y > test_y) {
+      positionMax = postionMid;
+    } else {
+      positionMin = postionMid;
+      break;
+    }
+  }
+  return positionMin;
+};
+
+ConnectionDB.prototype.sortAxisY = function() {
+  this.connections.sort((a, b) => a.Y_() - b.Y_());
+};
+
+export default ConnectionDB;

--- a/dragging.js
+++ b/dragging.js
@@ -1,0 +1,30 @@
+const Dragging = function() {
+  this.isDragging = false;
+  this.dragginBlock = undefined;
+  this.orginalX = 0;
+  this.orginalY = 0;
+  this.currentX = 0;
+  this.currentY = 0;
+};
+
+Dragging.prototype.dragStart = function(sourceBlock, x, y) {
+  this.isDragging = true;
+  this.orginalX = x;
+  this.orginalY = y;
+  this.dragginBlock = sourceBlock;
+};
+
+Dragging.prototype.updateDrag = function(x, y) {
+  this.currentX = x;
+  this.currentY = y;
+};
+
+Dragging.prototype.getCurrentBlockX = function() {
+  return this.currentX - this.orginalX + this.dragginBlock.X;
+};
+
+Dragging.prototype.getCurrentBlockY = function() {
+  return this.currentY - this.orginalY + this.dragginBlock.Y;
+};
+
+export default Dragging;


### PR DESCRIPTION
## 코드설명
- 스크래치의 기능인 블록들의 드래그 앤 드랍을 하기 위해 블록들이 연결될 수 있는 위치들인 커넥션 함수를 만들고 커넥션 db에 해당 함수들을 보관하도록 하여 drag 중에 가장 가까운 커넥션을 탐색할 수 있도록 blockly를 참고하여 구현하였습니다.
## 질문
- 커넥션들은 드랍될때 좌표 값이 바뀌어야하고 블록이 삭제되면 사라져야되는데 커넥션db를 계속 유지하면서 내부에 커넥션들을 찾아 수정하는 방식으로 구현하는 것과 드래그가 시작될때 블록들이 가지고 있는 커넥션들을 탐색하여 매번 생성하는 것 중 성능상 더 나은 방식이 무엇일까요?
- 해당코드는 드래그이벤트가 시작되고 마우스가 움직일때 마다 연결 가능한 위치를 찾도록 구현되어있는데 이러한 경우 서비스워커를 통해 따로 동작시키는 것이 더 나은 방법일까요?
