### PR TITLE
버그: 로그인시 헤더에 로그인한 유저의 사진이 안나오는 상황 수정

### DIFF
--- a/front/src/Components/Auth/index.js
+++ b/front/src/Components/Auth/index.js
@@ -16,10 +16,10 @@ export default () => {
       method: 'post',
       body: tokenBlob,
     });
-    setLoggedIn(data.result);
-    setOpen(!data.result);
     localStorage.setItem('token', data.token);
     localStorage.setItem('userImage', response.profileObj.imageUrl);
+    setLoggedIn(data.result);
+    setOpen(!data.result);
     if (!data.result) {
       alert('로그인이 되지 않았습니다. 다시 로그인해주세요');
     }


### PR DESCRIPTION
제대로 커밋 안 된 버그수정 재제출
재렌더링하기전에 localStorage에 먼저 토큰과 userImage를 넣는 것으로 수정