### PR TITLE
버그: block model의 input 클릭 시 에러 발생

### DIFF
--- a/front/src/Components/Block/Logic/Copy.js
+++ b/front/src/Components/Block/Logic/Copy.js
@@ -2,6 +2,10 @@ import motion from '../Init/Motion';
 
 export default ({ dispatch, motionIndex, setModel, setPosition }) => {
   const mousedown = (eventDown) => {
+    if (eventDown.target.tagName !== 'path') {
+      return;
+    }
+    eventDown.preventDefault();
     setModel(false);
     const blockParams = motion[motionIndex];
     blockParams.x = eventDown.target.getBoundingClientRect().x


### PR DESCRIPTION
- 클릭 대상이 path가 아닐 시 return
- event.preventDefault로 이벤트 전파 방지