### PR TITLE
버그: 위에 있는 블록 교체시 연결이 안 끊기던 버그 해결

### DIFF
--- a/front/src/Components/Block/block.js
+++ b/front/src/Components/Block/block.js
@@ -290,6 +290,9 @@ Block.prototype.connectBlock = function (type, conn) {
         lastBlock.setNextElement(this.nextElement);
         this.nextElement.setpreviousElement(lastBlock);
       }
+      if (conn.source.previousElement) {
+        conn.source.previousElement.setNextElement(null);
+      }
       conn.source.setpreviousElement(this);
       this.setNextElement(conn.source);
       this.setNextElementPosition();


### PR DESCRIPTION
위에 있는 블록 교체시 이전 블록에서 연결이 제대로 안끊겨 렌더링이 잘못되는 문제를 해결하였음.