### PR TITLE
버그: 변수명 오류 수정

### DIFF
--- a/front/src/Components/Block/dragging.js
+++ b/front/src/Components/Block/dragging.js
@@ -25,8 +25,8 @@ Dragging.prototype.dragStart = function (sourceBlock, x, y) {
 };
 
 Dragging.prototype.updateBlockPosition = function () {
-  this.sourceBlock.x = this.x;
-  this.sourceBlock.y = this.y;
+  this.draggedBlock.x = this.x;
+  this.draggedBlock.y = this.y;
   this.lastBlock.x = this.x + this.lastBlockDiff.x;
   this.lastBlock.y = this.y + this.lastBlockDiff.y;
 };


### PR DESCRIPTION
드래깅의 소스 블럭의 변수명이 잘못되어 x값을 접근하지 못하여 생기는 버그 수정