### PR TITLE
버그: for문의 값이 0일때 한번 동작하는 문제해결

### DIFF
--- a/front/src/Components/Block/functionMaker.js
+++ b/front/src/Components/Block/functionMaker.js
@@ -31,6 +31,7 @@ const FunctionList = {
     const codes = args.firstChild;
     function* FOR_LOOP() {
       while (codes) {
+        if (limit <= 0) yield i += 1;
         if (i >= limit) i = 0;
         if (j === codes.length) j = 0;
         while (j < codes.length) {


### PR DESCRIPTION
for문의 값이 0일때 예외처리 하여 동작하지 않도록 수정.