### PR TITLE
[임문수]w5_블록을_서버로 저장_불러오기_기능_구현

### DIFF
--- a/project.js
+++ b/project.js
@@ -1,0 +1,164 @@
+import React, { useReducer, useState, useCallback, useEffect } from 'react';
+import { useMutation, useLazyQuery } from '@apollo/react-hooks';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faStar } from '@fortawesome/free-solid-svg-icons';
+import Snackbar from '../Components/Snackbar';
+import Blockspace from '../Components/Block/index';
+import Workspace from '../Components/Block/workspace';
+import { WorkspaceContext, SpritesContext } from '../Context/index';
+import { workspaceReducer, spritesReducer } from '../reducer';
+import { CREATE_AND_SAVE, LOAD_PROJECT, UPDATE_BLOCK } from '../Apollo/queries/Project';
+import init from '../Components/Block/Init';
+
+let canSave = true;
+
+const Project = ({ match, history }) => {
+  const [projectId, setPorjectId] = useState();
+  const [projectName, setProjectName] = useState('');
+  const [ready, setReady] = useState(false);
+  const [workspace, workspaceDispatch] = useReducer(
+    workspaceReducer,
+    new Workspace(),
+  );
+  const makeBlock = (Blocks) => {
+    const blockTypes = {};
+    init.reduce((pre, cur) => [...pre, ...cur], []).forEach((data) => {
+      blockTypes[data.type] = data;
+    });
+    Blocks.forEach((blockData) => {
+      const block = workspace.addBlock(blockData.id);
+      const dataJSON = blockTypes[blockData.type];
+      dataJSON.x = blockData.positionX;
+      dataJSON.y = blockData.positionY;
+      block.x = blockData.positionX;
+      block.y = blockData.positionY;
+      block.makeFromJSON(dataJSON);
+    });
+    Blocks.forEach((blockData) => {
+      const block = workspace.getBlockById(blockData.id);
+      if (blockData.nextElementId) {
+        const nextBlock = workspace.getBlockById(blockData.nextElementId);
+        block.nextElement = nextBlock;
+        nextBlock.previousElement = block;
+      }
+      if (blockData.firstChildElementId) {
+        const firstChildBlock = workspace.getBlockById(blockData.firstChildElementId);
+        block.firstchildElement = firstChildBlock;
+        firstChildBlock.parentElement = block;
+      }
+      if (blockData.secondChildElementId) {
+        const secondChildElement = workspace.getBlockById(blockData.firstChildElementId);
+        block.secondchildElement = secondChildElement;
+        secondChildElement.parentElement = block;
+      }
+      if (blockData.inputElementId) {
+        block.inputElement = blockData.inputElementId.map(v => ({ type: 'input', value: v }));
+      }
+    });
+    Blocks.forEach((blockData) => {
+      const block = workspace.getBlockById(blockData.id);
+      if (!block.parentElement && !block.previousElement) {
+        workspace.addTopblock(block);
+      }
+    });
+  };
+  const [createAndSave] = useMutation(CREATE_AND_SAVE,
+    {
+      onCompleted(createAndSave) {
+        const projectId = createAndSave.createProjectAndBlocks;
+        if (projectId) {
+          history.push(`/project/${projectId}`);
+        }
+      },
+    });
+  const [updateProject] = useMutation(UPDATE_BLOCK, {
+    onCompleted(updateProject) {
+      const result = updateProject.updateProjectAndBlocks;
+      canSave = true;
+    },
+  });
+  const [loadProject] = useLazyQuery(LOAD_PROJECT,
+    {
+      onCompleted(loadProject) {
+        setProjectName(loadProject.findProjectById.title);
+        makeBlock(loadProject.findProjectById.blocks);
+        setReady(true);
+      },
+    });
+
+  const [snackbar, setSnackbar] = React.useState({
+    open: false,
+    vertical: 'top',
+    horizontal: 'center',
+    message: '로그인이 필요합니다.',
+    color: 'alertColor',
+  });
+
+  useEffect(() => {
+    if (match.params.name) {
+      setPorjectId(match.params.name);
+      loadProject({
+        variables: { projectId: match.params.name },
+      });
+    }
+  }, []);
+
+  const getProjectName = () => {
+    if (projectName.length < 1) {
+      setProjectName('임시이름');
+    }
+    return projectName;
+  };
+
+  const projectNameHandler = useCallback((e) => {
+    setProjectName(e.target.value);
+  }, []);
+
+  const saveHandler = () => {
+    if (!localStorage.getItem('token')) {
+      setSnackbar({ ...snackbar, open: true });
+      return;
+    }
+    canSave = false;
+    if (projectId) {
+      updateProject({
+        variables: { projectId,
+          projectTitle: getProjectName(),
+          input: workspace.extractCoreData() },
+      });
+    } else {
+      createAndSave({
+        variables: { projectTitle: getProjectName(), input: workspace.extractCoreData() },
+      });
+    }
+  };
+
+  return (
+    <WorkspaceContext.Provider value={{ workspace, workspaceDispatch }}>
+      <SpritesContext.Provider value={{ sprites, spritesDispatch }}>
+        <Wrapper>
+          <ProjectHeader isStared={dummyProject.star.toString()}>
+            <div className="project-info">
+              <input className="project-title" value={projectName} onChange={projectNameHandler} />
+              <button type="button">
+                <FontAwesomeIcon icon={faStar} className="star-icon" />
+              </button>
+
+              <button type="button">
+                {dummyProject.isPublic ? '전체 공개' : '비공개'}
+              </button>
+              <button type="button"> 초대 </button>
+              <button type="button" onClick={saveHandler}> 저장하기 </button>
+            </div>
+          </ProjectHeader>
+          <Contents>
+            <Blockspace />
+          </Contents>
+          <Snackbar snackbar={snackbar} setSnackbar={setSnackbar} />
+        </Wrapper>
+      </SpritesContext.Provider>
+    </WorkspaceContext.Provider>
+  );
+};
+
+export default Project;

--- a/queries/Project.js
+++ b/queries/Project.js
@@ -1,0 +1,55 @@
+import { gql } from 'apollo-boost';
+
+export const GET_PROJECTS = gql`
+  query findProjectsByUserId {
+    findProjectsByUserId {
+      id,
+      title,
+      like,
+      description,
+      owner {
+        email,
+        picture,
+      },
+    }
+  }
+`;
+
+export const DELETE_PROJECT = gql`
+  mutation deleteProjectAndBlocks($projectId: String!) {
+    deleteProjectAndBlocks(projectId: $projectId)
+  }
+`;
+
+export const CREATE_AND_SAVE = gql`
+  mutation createProjectAndBlocks($projectTitle: String!, $input: [createBlockInput]! ) {
+    createProjectAndBlocks(projectTitle: $projectTitle, input: $input)
+  }
+`;
+
+export const UPDATE_BLOCK = gql`
+  mutation updateProjectAndBlocks($projectId: String!, $projectTitle:String!, $input: [createBlockInput]!) {
+    updateProjectAndBlocks(projectId: $projectId, projectTitle: $projectTitle, input: $input)
+  }
+`;
+
+export const LOAD_PROJECT = gql`
+  query findProjectById($projectId: String!) {
+    findProjectById(projectId: $projectId) {
+      id,
+      title,
+      description,
+      like,
+      private,
+      blocks{
+        id,
+        type,
+        nextElementId,
+        firstChildElementId,
+        secondChildElementId,
+        positionX,
+        positionY,
+      },
+    }
+  }
+`;

--- a/workspace.js
+++ b/workspace.js
@@ -1,0 +1,53 @@
+/* eslint-disable class-methods-use-this */
+import Block from './block';
+import Dragging from './dragging';
+import ConnectionDB from './connection_db';
+
+const Workspace = class {
+  constructor(blockDB, topblocks, setRender) {
+    this.blockDB = blockDB || Object.create(null);
+    this.connectionDB = new ConnectionDB(this);
+    this.dragging = new Dragging(this.connectionDB);
+    this.topblocks = topblocks || [];
+    this.setRender = setRender || null;
+  }
+
+  addBlock(usedId) {
+    return new Block(this, usedId);
+  }
+
+  getStartBlocks() {
+    return this.topblocks.reduce((prev, cur) => {
+      if (cur.type === 'event_start' && cur.nextElement) prev.push(cur.nextElement);
+      return prev;
+    }, []);
+  }
+
+  addTopblock(block) {
+    if (this.topblocks.some(b => b.id === block.id)) return;
+    this.topblocks.push(block);
+  }
+  
+  getBlockById(blockId) {
+    return this.blockDB[blockId];
+  }
+
+  extractCoreData() {
+    return Object.values(this.blockDB).map(b => ({
+      id: b.id,
+      type: b.type,
+      positionX: b.x,
+      positionY: b.y,
+      nextElementId: this.getBlockId(b.nextElement),
+      firstChildElementId: this.getBlockId(b.firstchildElement),
+      secondChildElementId: this.getBlockId(b.secondchildElement),
+      inputElementId: b.inputElement.map(input => (input.id ? input.id : input.value.toString())),
+    }));
+  }
+
+  getBlockId(block) {
+    return block ? block.id : null;
+  }
+};
+
+export default Workspace;


### PR DESCRIPTION
## 구현사항
### 저장하기
- 워크스페이스로부터 extractCoreData 함수를 이용해 블록정보에서 필요한 데이터만 뽑아옵니다.
- 현재 project의 아이디를 확인하고 아이디가 없다면 프로젝트를 생성하면서 저장할 수 있도록  createAndSave 뮤테이션을 실행하고 프로젝트 아이디가 있다면 updateProject 뮤테이션을 통하여 업데이트 합니다.
- 서버로 전송이 끝났을때, 프로젝트를 생성한 경우 history를 이용하여 해당 프로젝트 id가 담긴 url로 변경합니다.
### 불러오기
- projectid가 담긴 url로 들어온 경우 해당 id로 서버에 데이터를 요청합니다.
- makeBlock 함수를 호출하여 블록 타입들에 대한 정보를 모아 객체로 생성합니다.
- 받은 데이터를 이용하여 block의 타입에 맞게 블록을 생성하고 위치값을 적용합니다.
- 생성된 블록들의 연결관계에 따라서 블록들을 연결해줍니다.
- 생성된 블록들의 연결이 끝난 후 상위 연결관계가 없는 블록들을 탑블록에 추가합니다.

