### PR TITLE
[유진관]w5_React.createElement->Component로 분리

### DIFF
--- a/Block/block.js
+++ b/Block/block.js
@@ -1,0 +1,425 @@
+import React from 'react';
+import Path from './Path';
+import Utils from '../../utils/utils';
+import Connection from './connection';
+import CONSTANTS from './constants';
+
+const create = React.createElement;
+const Block = class {
+  constructor(workspace, usedId) {
+    this.id = usedId;
+    this.type = '';
+    this.style = '';
+    this.workspace = workspace;
+    this.firstchildConnection = null;
+    this.secondchildConnection = null;
+    this.firstchildElement = null;
+    this.secondchildElement = null;
+    this.x = 0;
+    this.y = 0;
+    this.args = [];
+    this.color = '';
+    this.strokeColor = '';
+    this.previousConnection = null;
+    this.nextConnection = null;
+    this.previousElement = null;
+    this.nextElement = null;
+    this.path = null;
+    this.node = null;
+    this.render = null;
+    this.allIdx = -1;
+    this.styleIdx = -1;
+    this.isDragged = false;
+    this.parentElement = null;
+    this.parentConnection = null;
+    this.height = 0;
+    this.firstchildHeight = 24;
+    this.secondchildHeight = 24;
+    this.inputElement = [];
+    this.inputWidth = [];
+  }
+
+  setNode = (node) => {
+    this.node = node;
+    this.setArgs();
+  };
+
+  setArgs = () => {
+    if (this.node) {
+      let positionX = CONSTANTS.PIXEL;
+      let lastChild;
+      this.node.childNodes.forEach((node) => {
+        if (node.tagName !== 'path' && node.tagName !== 'g') {
+          this.setArgsPosition(node, positionX);
+          positionX += node.getBoundingClientRect().width;
+          lastChild = node;
+        }
+      });
+      if (this.firstchildHeight < 24) { this.firstchildHeight = 24; }
+      if (this.secondchildHeight < 24) { this.secondchildHeight = 24; }
+      this.makeStyleFromJSON(
+        (lastChild.getBoundingClientRect().right
+        - this.node.firstChild.getBoundingClientRect().left
+        - CONSTANTS.PIXEL * 5)
+        / CONSTANTS.PIXEL,
+        this.firstchildHeight / CONSTANTS.PIXEL - 2,
+        this.secondchildHeight / CONSTANTS.PIXEL - 2,
+      );
+      this.render(Math.random());
+      this.height = this.node.firstChild.getBoundingClientRect().height;
+      this.setConnectionPosition();
+    }
+  };
+
+  setArgsPosition = (node, positionX) => {
+    if (node.tagName !== 'foreignObject') {
+      node.setAttribute('transform', `translate(${positionX},23)`);
+    } else {
+      node.setAttribute('transform', `translate(${positionX + 3},8)`);
+    }
+  };
+
+  setConnectionPosition = () => {
+    if (this.previousConnection) {
+      this.previousConnection = new Connection(
+        CONSTANTS.PREVIOUS_CONNECTION,
+        this, 'previousPosition',
+      );
+      this.previousConnection.setPositions();
+    }
+
+    if (this.nextConnection) {
+      this.nextConnection = new Connection(
+        CONSTANTS.NEXT_CONNECTION,
+        this, 'nextPosition',
+      );
+      this.nextConnection.setPositions();
+    }
+
+    if (this.firstchildConnection) {
+      this.firstchildConnection = new Connection(
+        CONSTANTS.NEXT_CONNECTION,
+        this, 'firstChildPosition',
+      );
+      this.firstchildConnection.setPositions();
+    }
+  }
+
+  changeInputWidth = (set, index) => (event) => {
+    const { target } = event;
+    const { length } = target.value;
+    if (length > 5) {
+      const { lastChild } = target.parentNode;
+      lastChild.innerHTML = target.value;
+      this.inputWidth[index] = lastChild.clientWidth;
+    } else {
+      this.inputWidth[index] = 30;
+    }
+    target.parentNode.style.width = `${this.inputWidth[index]}px`;
+    target.style.width = `${this.inputWidth[index]}px`;
+    this.inputElement[index].value = target.value;
+    if (set) { set(target.value); }
+    this.setArgs();
+  };
+
+  makeFromJSON = (json) => {
+    this.type = json.type;
+    this.color = json.color;
+    this.strokeColor = json.stroke_color;
+    this.x = json.x ? json.x : 0;
+    this.y = json.y ? json.y : 0;
+    this.allIdx = json.allIdx === 0 || Number(json.allIdx) ? json.allIdx : -1;
+    this.styleIdx = json.styleIdx === 0 || Number(json.styleIdx) ? json.styleIdx : -1;
+
+
+    if (!this.id) {
+      this.id = Utils.uid();
+    }
+
+    json.args.forEach((arg) => {
+      this.makeArgsFromJSON(arg);
+    });
+
+    this.style = json.style;
+    this.makeStyleFromJSON();
+
+    if (json.previousConnection) {
+      this.previousConnection = true;
+    }
+
+    if (json.nextConnection) {
+      this.nextConnection = true;
+    }
+
+    if (json.firstchildConnection) {
+      this.firstchildConnection = true;
+    }
+
+    if (!this.workspace.getBlockById(this.id)) {
+      this.workspace.blockDB[this.id] = this;
+    }
+  };
+
+  makeArgsFromJSON = (json) => {
+    if (json.type === 'text') {
+      this.args.push(create(json.type, { key: json.value }, json.value));
+    } else if (json.type === 'input') {
+      this.inputElement.push({ type: json.type, value: json.value });
+      this.args.push('input');
+    }
+  };
+
+  makeStyleFromJSON = (width, height, secondHeight) => {
+    switch (this.style) {
+      case 'single':
+        this.path = create(
+          'path',
+          {
+            d: Path.single(width),
+            fill: this.color,
+            stroke: this.strokeColor,
+            strokeWidth: 1,
+            key: 'single',
+          },
+          null,
+        );
+        break;
+      case 'double':
+        this.path = create(
+          'path',
+          {
+            d: Path.double(width, height),
+            fill: this.color,
+            stroke: this.strokeColor,
+            strokeWidth: 1,
+            key: 'double',
+          },
+          null,
+        );
+        break;
+      case 'triple':
+        this.path = create(
+          'path',
+          {
+            d: Path.triple(width, height, secondHeight),
+            fill: this.color,
+            stroke: this.strokeColor,
+            strokeWidth: 1,
+            key: 'triple',
+          },
+          null,
+        );
+        break;
+      case 'variable':
+        this.path = create(
+          'path',
+          {
+            d: Path.variable(width),
+            fill: this.color,
+            stroke: this.strokeColor,
+            strokeWidth: 1,
+            key: 'variable',
+          },
+          null,
+        );
+        break;
+      case 'event':
+        this.path = create(
+          'path',
+          {
+            d: Path.event(width),
+            fill: this.color,
+            stroke: this.strokeColor,
+            strokeWidth: 1,
+            key: 'event',
+          },
+          null,
+        );
+        break;
+      case 'condition':
+        this.path = create(
+          'path',
+          {
+            d: Path.condition(width),
+            fill: this.color,
+            stroke: this.strokeColor,
+            strokeWidth: 1,
+            key: 'condition',
+          },
+          null,
+        );
+        break;
+      default:
+        throw new Error("It's not a defined style!!");
+    }
+  };
+
+  dragStart = (x, y) => {
+    this.setDrag(true);
+    this.workspace.dragStart(this, x, y);
+  };
+
+  dragUpdate = (x, y) => {
+    this.workspace.dragUpdate(x, y);
+  };
+
+  dragEnd = (x, y) => {
+    this.x = x;
+    this.y = y;
+    this.setDrag(false);
+    this.workspace.dragEnd();
+  };
+
+  getLastBlock = (goEndPoint = false) => {
+    if (this.nextElement && goEndPoint) {
+      return this.nextElement.getLastBlock(goEndPoint);
+    }
+
+    return this;
+  };
+
+  setDrag = (isDragged) => {
+    this.isDragged = isDragged;
+    if (this.nextElement) {
+      this.nextElement.setDrag(isDragged);
+    }
+
+    if (this.firstchildElement) {
+      this.firstchildElement.setDrag(isDragged);
+    }
+
+    if (this.secondchildElement) {
+      this.secondchildElement.setDrag(isDragged);
+    }
+  };
+
+  getAvailableConnection = (isDragged = false) => {
+    const availableConnection = [];
+
+    if (this.previousConnection && this.parentElement === null) {
+      availableConnection.push(this.previousConnection);
+    }
+
+    if (this.nextConnection) {
+      const nextConn = this.getLastBlock(isDragged).nextConnection;
+      if (nextConn) availableConnection.push(nextConn);
+    }
+
+    if (this.firstchildConnection) {
+      availableConnection.push(this.firstchildConnection);
+    }
+
+    return availableConnection;
+  };
+
+  setNextElementPosition = () => {
+    if (this.firstchildElement) {
+      this.setFirstChildPosition();
+      this.firstchildHeight = this.firstchildElement.node.getBoundingClientRect().height
+      - CONSTANTS.PIXEL;
+    }
+    if (this.nextElement) {
+      this.nextElement.y = this.y + this.height - CONSTANTS.PIXEL;
+      this.nextElement.x = this.x;
+      this.nextElement.setNextElementPosition();
+    }
+    this.setArgs();
+  };
+
+  setFirstChildPosition = () => {
+    this.firstchildElement.y = this.y + CONSTANTS.BLOCK_HEAD_HEIGHT;
+    this.firstchildElement.x = this.x + CONSTANTS.PREVIOUS_NEXT_POS_X;
+    this.firstchildElement.setNextElementPosition();
+  }
+
+  setpreviousElement = (previousElement) => {
+    this.previousElement = previousElement;
+  };
+
+  setNextElement = (nextElement) => {
+    this.nextElement = nextElement;
+  };
+
+  setParentElement = (parentElement) => {
+    this.parentElement = parentElement;
+  }
+
+  setFirstChildElement = (firstchildElement) => {
+    this.firstchildElement = firstchildElement;
+  }
+
+  setSecondChildElement = (secondchildElement) => {
+    this.secondchildElement = secondchildElement;
+  }
+
+  connectBlock = (type, conn) => {
+    switch (type) {
+      case 'nextPosition':
+        Utils.arrayRemove(this.workspace.topblocks, conn.source);
+        if (this.nextElement) {
+          const lastBlock = conn.source.getLastBlock(true);
+          lastBlock.setNextElement(this.nextElement);
+          this.nextElement.setpreviousElement(lastBlock);
+        }
+        if (conn.source.previousElement) {
+          conn.source.previousElement.setNextElement(null);
+        }
+        conn.source.setpreviousElement(this);
+        this.setNextElement(conn.source);
+        break;
+      case 'previousPosition':
+        if (conn.positiontype === 'nextPosition') {
+          if (conn.source.nextElement) {
+            const lastBlock = this.getLastBlock(true);
+            conn.source.nextElement.setpreviousElement(lastBlock);
+            lastBlock.setNextElement(conn.source.nextElement);
+          }
+          this.previousElement = conn.source;
+          conn.source.setNextElement(this);
+        } else if (conn.positiontype === 'firstChildPosition') {
+          if (conn.source.firstchildElement) {
+            const lastBlock = this.getLastBlock(true);
+            conn.source.firstchildElement.setpreviousElement(lastBlock);
+            conn.source.firstchildElement.parentElement = null;
+            lastBlock.setNextElement(conn.source.firstchildElement);
+          }
+          this.parentElement = conn.source;
+          conn.source.setFirstChildElement(this);
+        }
+        break;
+      case 'outputPosition':
+        break;
+      case 'inputPosition':
+        break;
+      case 'firstChildPosition':
+        break;
+      case 'secondChildPosition':
+        break;
+      default:
+        throw new Error('잘못된 커넥션 타입입니다.');
+    }
+  };
+
+  disconnectBlock = () => {
+    if (this.previousElement) {
+      this.previousElement.nextElement = null;
+      this.previousElement = null;
+    }
+    if (this.parentElement) {
+      if (this.parentElement.firstchildElement === this) {
+        this.parentElement.firstchildHeight -= this.node.getBoundingClientRect().height - CONSTANTS.PIXEL;
+        this.parentElement.firstchildElement = null;
+        this.parentElement = null;
+      } else if (this.parentElement.secondchildElement === this) {
+        this.parentElement.secondchildElement = null;
+        this.parentElement = null;
+      }
+    }
+  };
+
+  setAllBlockPosition = () => {
+    this.setNextElementPosition();
+  }
+};
+
+export default Block;

--- a/Group/index.js
+++ b/Group/index.js
@@ -1,0 +1,62 @@
+import React, { useState, useContext, useRef, useEffect } from 'react';
+import PropType from 'prop-types';
+import drag from '../Block/Logic/Drag';
+import { WorkspaceContext } from '../../Context';
+import CONSTANTS from '../Block/constants';
+import Input from './input';
+
+const Group = ({ block }) => {
+  // eslint-disable-next-line
+  let [isMoved, setMoved] = useState(true);
+  const [position, setPosition] = useState({ x: block.x, y: block.y });
+  if (block.previousElement && position.y !== block.previousElement.height - CONSTANTS.PIXEL) {
+    setPosition({ x: 0, y: block.previousElement.height - CONSTANTS.PIXEL });
+  }
+  if (block.parentElement && position.y !== CONSTANTS.BLOCK_HEAD_HEIGHT) {
+    setPosition({ x: CONSTANTS.PREVIOUS_NEXT_POS_X, y: CONSTANTS.BLOCK_HEAD_HEIGHT });
+  }
+  const { workspaceDispatch } = useContext(WorkspaceContext);
+  const [, setRender] = useState();
+  const gRef = useRef();
+  let inputIdx = -1;
+  useEffect(() => {
+    // eslint-disable-next-line
+    block.render = setRender;
+    block.setNode(gRef.current);
+  }, []);
+  if (block.previousElement || block.parentElement) isMoved = true;
+  return (
+    <g
+      data-id={block.id}
+      key={block.id}
+      ref={gRef}
+      onMouseLeave={isMoved ? () => {} : () => {
+        workspaceDispatch({
+          type: 'DELETE_BLOCK',
+          id: block.id,
+        });
+      }}
+      onMouseDown={
+          drag({ set: setPosition, block, setMoved, workspaceDispatch })
+      }
+      transform={`translate(${position.x},${position.y})`}
+    >
+      {block.path}
+      {block.args.map((args) => {
+        if (args !== 'input') return args;
+        inputIdx += 1; return <Input block={block} index={inputIdx} key={block.id} />;
+      })}
+      {block.firstchildElement
+      && <Group block={block.firstchildElement} key={block.firstchildElement.id} />}
+      {block.secondchildElement
+      && <Group block={block.secondchildElement} key={block.secondchildElement.id} />}
+      {block.nextElement && <Group block={block.nextElement} key={block.nextElement.id} />}
+    </g>
+  );
+};
+
+Group.propTypes = {
+  block: PropType.object.isRequired,
+};
+
+export default Group;

--- a/Group/input.js
+++ b/Group/input.js
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import PropType from 'prop-types';
+
+const Input = ({ block, index }) => {
+  const [value, setValue] = useState(block.inputElement[index].value);
+  return (
+    <>
+      <foreignObject style={{ width: block.inputWidth[index] }}>
+        <input
+          style={{ width: block.inputWidth[index] }}
+          value={value}
+          onChange={block.changeInputWidth(setValue, index).bind(block)}
+        />
+        <HiddenArea />
+      </foreignObject>
+    </>
+  );
+};
+
+Input.propTypes = {
+  block: PropType.object.isRequired,
+  index: PropType.number.isRequired,
+};
+
+const HiddenArea = styled.div`
+  position: absolute;
+  visibility: hidden;
+  font-size: 0.5rem;
+`;
+
+export default Input;


### PR DESCRIPTION
### 지난 주 리뷰에서 실행되는 파일을 통으로 올리고 리뷰받고 싶은 부분을 선택해 달라 하셔서 해당 파일은 전부 첨부했습니다.
### 변경 사항만 따로 보시기에는 https://github.com/connect-foundation/2019-13/pull/141/files 참고 해주시면 감사하겠습니다.

### 구현 사항
- 기존 객체에서 React.createElement로 생성하던 부분을 useState hooks를 활용하여 input값 변경이 불가능한 상태라고 판단하여, 컴포넌트로 빼내었습니다.

### 질문 사항
1. React hooks를 사용하려면 변경한 것 처럼, 컴포넌트화하여 사용하는 수밖에 없나요? 컴포넌트 이외에서 사용이 안 되던데, 혹시 다른 방법이 있는지 궁금합니다.
2. 현재 이 구현사항과는 관련이 없는 내용인데, 리액트에서 컴포넌트가 렌더링이 된 후에 다시 검사하여 재 렌더링 시키는 방식으로 현재 깨지는 블록들을 처리할 예정인데, 상당한 부하가 예상되는 상황입니다. 리액트 쓰로틀링 이외에 렌더링에 가해지는 부담을 더 줄일 수 있는 방법이 있나요?