### PR TITLE
버그: 좋아요가 눌러져있을경우 프로젝트가 삭제 안되는현상 수정

### DIFF
--- a/back/datamodel.prisma
+++ b/back/datamodel.prisma
@@ -18,7 +18,7 @@ type Project {
   canvasImage: String!
   realCanvasImage: String!
   authes: [ProjectAuth]! @relation(name: "AuthesByProject")
-  likes: [Like]! @relation(name : "LikesByProject")
+  likes: [Like]! @relation(name : "LikesByProject" onDelete: CASCADE)
   comments: [Comment]! @relation(name : "CommentByProject" onDelete: CASCADE)
   workspaces: [Workspace]! @relation(name : "WorkspacesByProject" onDelete: CASCADE)
 }


### PR DESCRIPTION
- 삭제 안되는 이유
  - project와 like간에 foreign key로 연결되어있어서 likes를 삭제할경우 project의 id는 없는데 like의 project는 아직 남아있기 때문에 DB에서 지우지 못한다는 에러를 띄워버림
- 해결방법
  - project삭제할때 다 삭제되게 CASCADE설정을 해주면 된다.
 (다른방법은 project삭제전에 project와 관련된 like를 지워주면된다.)
