### PR TITLE
버그:[HotFix] detailCanvas에서 x,y좌표 이미지 비율대로 안나오는현상

### DIFF
--- a/front/src/Components/URLImage/index.js
+++ b/front/src/Components/URLImage/index.js
@@ -20,8 +20,8 @@ const URLImage = ({
   if (!draggable) {
     return (
       <Image
-        x={canvasSize.WIDTH / 2 + Number(sprite.x)}
-        y={canvasSize.HEIGHT / 2 + Number(sprite.y)}
+        x={canvasSize.WIDTH / 2 + Number((sprite.x) * canvasSize.SCALE)}
+        y={canvasSize.HEIGHT / 2 + Number((sprite.y) * canvasSize.SCALE)}
         image={image}
         scaleX={canvasSize.SCALE}
         scaleY={sprite.reversal ? -canvasSize.SCALE : canvasSize.SCALE}


### PR DESCRIPTION
x,y좌표에다 비율적용